### PR TITLE
feat: 마이페이지 UI 개편 및 주문 내역 기능 구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,8 @@ import "./globals.css";
 import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
 
+import { SessionProvider } from '@/components/providers/SessionProvider';
+
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
@@ -19,13 +21,15 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className={inter.className}>
-        <div className="flex flex-col min-h-screen">
-          <Header />
-          <main className="flex-grow">
-            {children}
-          </main>
-          <Footer />
-        </div>
+        <SessionProvider>
+          <div className="flex flex-col min-h-screen">
+            <Header />
+            <main className="flex-grow">
+              {children}
+            </main>
+            <Footer />
+          </div>
+        </SessionProvider>
       </body>
     </html>
   );

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,23 +1,52 @@
 'use client';
 
-import { useState } from 'react'; // Keep useState for activeTab
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import ProfileEditor from '@/components/mypage/ProfileEditor';
 import OrderHistory from '@/components/mypage/OrderHistory';
 import PasswordChanger from '@/components/mypage/PasswordChanger';
-import { useSession } from '@/components/providers/SessionProvider'; // Import useSession
+import { useSession } from '@/components/providers/SessionProvider';
+import { logout } from '@/app/auth/actions'; // Import logout action
+import { getProfile } from '@/app/mypage/actions'; // Import getProfile from mypage actions
 
-type Tab = 'profile' | 'orders' | 'password';
+// Placeholder Components (will be created below)
+const RewardPointsHistory = () => <div className="p-4">적립금 내역</div>;
+const CouponHistory = () => <div className="p-4">쿠폰 내역</div>;
+const ShippingAddressManagement = () => <div className="p-4">배송주소록 관리</div>;
+const RecentlyViewedProducts = () => <div className="p-4">최근 본 상품</div>;
+const MyWishlist = () => <div className="p-4">나의 위시 리스트</div>;
+const MyReviews = () => <div className="p-4">나의 리뷰</div>;
+
+type MenuItem = 'orderHistory' | 'rewardPoints' | 'coupon' | 'shippingAddress' | 'recentlyViewed' | 'wishlist' | 'myReviews' | 'editProfile' | 'passwordChange' | 'logout';
 
 const MyPage = () => {
-  const { user, loading } = useSession(); // Use session from provider
-  const [activeTab, setActiveTab] = useState<Tab>('profile'); // Default to profile tab
+  const { user, loading } = useSession();
+  const [profile, setProfile] = useState<{ username: string | null; full_name: string | null; } | null>(null);
+  const [loadingProfile, setLoadingProfile] = useState(true);
+  console.log('MyPage: Rendered', { user, loading });
+  const [activeItem, setActiveItem] = useState<MenuItem>('orderHistory'); // Default to Order History
 
-  if (loading) {
+  useEffect(() => {
+    if (user) {
+      const fetchProfileData = async () => {
+        setLoadingProfile(true);
+        const { data, error } = await getProfile();
+        if (!error && data) {
+          setProfile(data);
+        }
+        setLoadingProfile(false);
+      };
+      fetchProfileData();
+    }
+  }, [user]);
+
+  if (loading || loadingProfile) {
+    console.log('MyPage: Showing loading state', { user, loading, loadingProfile });
     return <div className="flex justify-center items-center h-screen">Loading...</div>;
   }
 
   if (!user) {
+    console.log('MyPage: Showing login required state', { user, loading });
     return (
       <div className="flex flex-col items-center justify-center h-screen text-black">
         <h1 className="text-2xl font-bold mb-4">로그인이 필요합니다.</h1>
@@ -26,51 +55,74 @@ const MyPage = () => {
     );
   }
 
+  const renderContent = () => {
+    switch (activeItem) {
+      case 'orderHistory':
+        return <OrderHistory />;
+      case 'rewardPoints':
+        return <RewardPointsHistory />;
+      case 'coupon':
+        return <CouponHistory />;
+      case 'shippingAddress':
+        return <ShippingAddressManagement />;
+      case 'recentlyViewed':
+        return <RecentlyViewedProducts />;
+      case 'wishlist':
+        return <MyWishlist />;
+      case 'myReviews':
+        return <MyReviews />;
+      case 'editProfile':
+        return <ProfileEditor />;
+      case 'passwordChange':
+        return <PasswordChanger />;
+      default:
+        return <OrderHistory />;
+    }
+  };
+
   return (
-    <div className="min-h-screen flex flex-col items-center bg-gray-100 p-4 text-black pt-20"> {/* Added pt-20 for header */}
-      <h1 className="text-4xl font-bold mb-8">마이페이지</h1>
-      <div className="bg-white p-8 rounded-lg shadow-md w-full max-w-3xl">
-        {/* Tab Navigation */}
-        <div className="border-b border-gray-200 mb-6">
-          <nav className="-mb-px flex space-x-8" aria-label="Tabs">
-            <button
-              onClick={() => setActiveTab('profile')}
-              className={`${
-                activeTab === 'profile'
-                  ? 'border-gray-900 text-gray-900'
-                  : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
-              } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm`}
-            >
-              프로필 수정
-            </button>
-            <button
-              onClick={() => setActiveTab('orders')}
-              className={`${
-                activeTab === 'orders'
-                  ? 'border-gray-900 text-gray-900'
-                  : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
-              } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm`}
-            >
-              주문 내역
-            </button>
-            <button
-              onClick={() => setActiveTab('password')}
-              className={`${
-                activeTab === 'password'
-                  ? 'border-gray-900 text-gray-900'
-                  : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
-              } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm`}
-            >
-              비밀번호 변경
-            </button>
+    <div className="min-h-screen flex flex-col bg-white text-black pt-20">
+      <div className="w-full max-w-5xl mx-auto px-4 mb-8 text-center">
+        <h1 className="text-2xl font-bold">안녕하세요 {profile?.full_name || profile?.username || user?.email} 고객님!</h1>
+      </div>
+      <div className="bg-white w-full flex p-8">
+        {/* Sidebar Navigation */}
+        <div className="w-64 pr-8">
+          <nav className="space-y-6">
+            <div>
+              <h2 className="text-xl font-semibold mb-4">쇼핑 정보</h2>
+              <ul className="space-y-2">
+                <li><button onClick={() => setActiveItem('orderHistory')} className={`block text-left w-full ${activeItem === 'orderHistory' ? 'font-bold text-gray-900' : 'text-gray-600 hover:text-gray-900'}`}>주문내역 조회</button></li>
+                <li><button onClick={() => setActiveItem('rewardPoints')} className={`block text-left w-full ${activeItem === 'rewardPoints' ? 'font-bold text-gray-900' : 'text-gray-600 hover:text-gray-900'}`}>적립금 내역</button></li>
+                <li><button onClick={() => setActiveItem('coupon')} className={`block text-left w-full ${activeItem === 'coupon' ? 'font-bold text-gray-900' : 'text-gray-600 hover:text-gray-900'}`}>쿠폰 내역</button></li>
+                <li><button onClick={() => setActiveItem('shippingAddress')} className={`block text-left w-full ${activeItem === 'shippingAddress' ? 'font-bold text-gray-900' : 'text-gray-600 hover:text-gray-900'}`}>배송주소록 관리</button></li>
+              </ul>
+            </div>
+            <div>
+              <h2 className="text-xl font-semibold mb-4">나의 활동</h2>
+              <ul className="space-y-2">
+                <li><button onClick={() => setActiveItem('recentlyViewed')} className={`block text-left w-full ${activeItem === 'recentlyViewed' ? 'font-bold text-gray-900' : 'text-gray-600 hover:text-gray-900'}`}>최근 본 상품</button></li>
+                <li><button onClick={() => setActiveItem('wishlist')} className={`block text-left w-full ${activeItem === 'wishlist' ? 'font-bold text-gray-900' : 'text-gray-600 hover:text-gray-900'}`}>나의 위시 리스트</button></li>
+                <li><button onClick={() => setActiveItem('myReviews')} className={`block text-left w-full ${activeItem === 'myReviews' ? 'font-bold text-gray-900' : 'text-gray-600 hover:text-gray-900'}`}>나의 리뷰</button></li>
+              </ul>
+            </div>
+            <div>
+              <h2 className="text-xl font-semibold mb-4">나의 정보</h2>
+              <ul className="space-y-2">
+                <li><button onClick={() => setActiveItem('editProfile')} className={`block text-left w-full ${activeItem === 'editProfile' ? 'font-bold text-gray-900' : 'text-gray-600 hover:text-gray-900'}`}>회원정보 수정</button></li>
+                <li>
+                  <form action={logout}>
+                    <button type="submit" className="block text-left w-full text-gray-600 hover:text-gray-900">로그아웃</button>
+                  </form>
+                </li>
+              </ul>
+            </div>
           </nav>
         </div>
 
-        {/* Tab Content */}
-        <div>
-          {activeTab === 'profile' && <ProfileEditor />} 
-          {activeTab === 'orders' && <OrderHistory />} 
-          {activeTab === 'password' && <PasswordChanger />} 
+        {/* Main Content Area */}
+        <div className="flex-1 pl-8">
+          {renderContent()}
         </div>
       </div>
     </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,37 +1,15 @@
 
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 import { Search, User, ShoppingCart, Menu } from 'lucide-react';
-import SideMenu from './SideMenu'; // Assuming SideMenu is in the same directory
-import { createClient } from '@/utils/supabase/client';
-import { logout } from '@/app/auth/actions';
-import type { User as SupabaseUser } from '@supabase/supabase-js';
+import SideMenu from './SideMenu';
+import { useSession } from '../providers/SessionProvider';
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [user, setUser] = useState<SupabaseUser | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const supabase = createClient();
-    const getUser = async () => {
-      const { data: { user } } = await supabase.auth.getUser();
-      setUser(user);
-      setLoading(false);
-    };
-
-    getUser();
-
-    const { data: authListener } = supabase.auth.onAuthStateChange((event, session) => {
-      setUser(session?.user ?? null);
-    });
-
-    return () => {
-      authListener.subscription.unsubscribe();
-    };
-  }, []);
+  const { user, loading } = useSession();
 
   const toggleMenu = () => {
     setIsMenuOpen(!isMenuOpen);

--- a/src/components/mypage/OrderHistory.tsx
+++ b/src/components/mypage/OrderHistory.tsx
@@ -1,13 +1,76 @@
 
 'use client';
 
-// TODO: Implement order history functionality
+import { useEffect, useState } from 'react';
+import { getOrders } from '@/app/mypage/actions';
+import type { Order } from '@/utils/supabase/types';
 
 export default function OrderHistory() {
+  const [orders, setOrders] = useState<Order[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchOrders = async () => {
+      setLoading(true);
+      const { data, error } = await getOrders();
+      if (error) {
+        setError(error.message);
+      } else {
+        setOrders(data);
+      }
+      setLoading(false);
+    };
+
+    fetchOrders();
+  }, []);
+
+  if (loading) {
+    return <div>주문 내역을 불러오는 중...</div>;
+  }
+
+  if (error) {
+    return <div className="text-red-500">오류: {error}</div>;
+  }
+
+  if (!orders || orders.length === 0) {
+    return (
+      <div>
+        <h2 className="text-2xl font-bold mb-4">주문 내역</h2>
+        <p>주문 내역이 없습니다.</p>
+      </div>
+    );
+  }
+
   return (
     <div>
       <h2 className="text-2xl font-bold mb-4">주문 내역</h2>
-      <p>주문 내역이 여기에 표시됩니다.</p>
+      <div className="space-y-6">
+        {orders.map((order) => (
+          <div key={order.id} className="border p-4 rounded-lg shadow-sm">
+            <div className="flex justify-between items-center mb-2">
+              <p className="font-semibold">주문 번호: {order.id}</p>
+              <p className="text-sm text-gray-600">주문일: {new Date(order.create_at).toLocaleDateString()}</p>
+            </div>
+            <p>총 금액: {order.total_price.toLocaleString()}원</p>
+            <p>상태: {order.status}</p>
+            {order.order_items && order.order_items.length > 0 && (
+              <div className="mt-4 border-t pt-4">
+                <h3 className="font-medium mb-2">주문 상품</h3>
+                <ul className="space-y-2">
+                  {order.order_items.map((item) => (
+                    <li key={item.id} className="flex justify-between text-sm text-gray-700">
+                      <span>상품 ID: {item.varnt_id}</span>
+                      <span>수량: {item.qutitay}</span>
+                      <span>가격: {item.price_at_purchase.toLocaleString()}원</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/mypage/ProfileEditor.tsx
+++ b/src/components/mypage/ProfileEditor.tsx
@@ -10,20 +10,29 @@ const ProfileEditor = () => {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
-  useEffect(() => {
-    const fetchProfile = async () => {
-      setLoading(true);
-      const { data, error } = await getProfile();
-      if (error) {
-        setError(error.message);
-      } else {
-        setProfile(data);
-      }
-      setLoading(false);
-    };
+  const fetchProfile = async () => {
+    setLoading(true);
+    const { data, error } = await getProfile();
+    if (error) {
+      setError(error.message);
+    } else {
+      setProfile(data);
+    }
+    setLoading(false);
+  };
 
+  useEffect(() => {
     fetchProfile();
   }, []);
+
+  useEffect(() => {
+    if (success) {
+      const timer = setTimeout(() => {
+        setSuccess(null);
+      }, 3000); // 3초 후 메시지 사라짐
+      return () => clearTimeout(timer);
+    }
+  }, [success]);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -44,6 +53,7 @@ const ProfileEditor = () => {
       setError(error.message);
     } else {
       setSuccess('프로필이 성공적으로 업데이트되었습니다.');
+      fetchProfile(); // Update: Re-fetch profile after successful update
     }
   };
 

--- a/src/components/providers/SessionProvider.tsx
+++ b/src/components/providers/SessionProvider.tsx
@@ -21,18 +21,25 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     const supabase = createClient();
 
     const getSession = async () => {
-      const { data: { session } } = await supabase.auth.getSession();
-      setSession(session);
-      setUser(session?.user || null);
-      setLoading(false);
+      console.log('SessionProvider: Initial getSession call');
+      try {
+        const { data: { session } } = await supabase.auth.getSession();
+        setSession(session);
+        setUser(session?.user || null);
+      } finally {
+        setLoading(false);
+        console.log('SessionProvider: Initial session loaded', { session, user: session?.user, loading: false });
+      }
     };
 
     getSession();
 
-    const { data: authListener } = supabase.auth.onAuthStateChange((_event, session) => {
+    const { data: authListener } = supabase.auth.onAuthStateChange((event, session) => {
+      console.log('SessionProvider: Auth state changed', { event, session, user: session?.user });
       setSession(session);
       setUser(session?.user || null);
       setLoading(false);
+      console.log('SessionProvider: Auth state updated', { session, user: session?.user, loading: false });
     });
 
     return () => {

--- a/src/utils/supabase/types.ts
+++ b/src/utils/supabase/types.ts
@@ -5,3 +5,20 @@ export type Profile = {
   email?: string;
   updated_at?: string;
 };
+
+export type Order = {
+  id: number;
+  user_id: string;
+  total_price: number;
+  status: string;
+  create_at: string;
+  order_items?: OrderItem[]; // Optional, to include items with order
+};
+
+export type OrderItem = {
+  id: number;
+  order_id: number;
+  varnt_id: number; // Assuming this is variant_id
+  qutitay: number; // Assuming this is quantity
+  price_at_purchase: number;
+};


### PR DESCRIPTION
- 마이페이지 UI를 사이드바 내비게이션 구조로 개편.
- 마이페이지 상단에 사용자 이름/이메일을 포함한 인사말 추가.
- 프로필 수정 기능 개선 (오류 수정, 이메일 표시, 메시지 자동 사라짐).
- 주문 내역 기능 구현 (Supabase 타입 정의, `getOrders` 서버 액션, `OrderHistory` 컴포넌트).
- `SessionProvider` 로딩 문제 및 `useEffect` import 오류 등 마이페이지 관련 버그 수정.
- `Login_Mypage.md`에 최신 개발 요약 추가.